### PR TITLE
Fix linkChecker: transform root-relative links, add PR trigger for live branch

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -1,7 +1,10 @@
 name: Validate existing links
 
 on:
+  pull_request:
   push:
+    branches-ignore:
+      - live
   repository_dispatch:
   workflow_dispatch:
   schedule:
@@ -16,13 +19,22 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Resolve root-relative links for checking
+        run: |
+          # Convert root-relative markdown links like [text](/path) to [text](https://learn.microsoft.com/path)
+          # so lychee can validate them. This only modifies the CI checkout copy.
+          find . -name '*.md' -exec sed -i -E 's|\]\(/|\](https://learn.microsoft.com/|g' {} +
+          # Replace unparseable http://localhost:port (literal word "port") with a valid placeholder
+          # so lychee doesn't fail on URL parsing
+          find . -name '*.md' -exec sed -i 's|http://localhost:port|http://localhost:0|g' {} +
+
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@master
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
-          args: --accept=200,429,403,502,503 --verbose --no-progress './**/*.md'
+          args: --accept=200,429,403,502,503 --exclude 'http://localhost' --verbose --no-progress './**/*.md'
           fail: true
 
       - name: Create Issue From File

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -7,5 +7,5 @@ https://account.microsoft.com.*
 https://azure.microsoft.com/overview/azure-stack.*
 https://azure.microsoft.com/products/kubernetes-service.*
 github.com/AzureAD/microsoft-authentication-library-for-go/apps/public
-http://localhost:port
-file:///home/runner/work/microsoft-authentication-library-for-go/microsoft-authentication-library-for-go/msal-go/packages/public/http:/localhost:port
+http://localhost.*
+https://aka.ms/region-map

--- a/msal-go/advanced/managed-identity.md
+++ b/msal-go/advanced/managed-identity.md
@@ -9,7 +9,7 @@ ms.date: 02/11/2025
 # Managed Identity with MSAL GO
 
 >[!NOTE]
->This feature is available starting with MSAL for Go version [`1.3.0-preview`](https://github.com/AzureAD/microsoft-authentication-library-for-go/releases/tag/v1.3.0-preview).
+>This feature is available starting with MSAL for Go version [`1.3.1`](https://github.com/AzureAD/microsoft-authentication-library-for-go/releases/tag/v1.3.1).
 
 A common challenge for developers is the management of secrets, credentials, certificates, and keys used to secure communication between services. [Managed identities](/azure/active-directory/managed-identities-azure-resources/overview) in Azure eliminate the need for developers to handle these credentials manually. MSAL for Go supports acquiring tokens through the managed identity service when used with applications running inside Azure infrastructure, such as:
 


### PR DESCRIPTION
This pull request introduces several improvements to link validation in the CI workflow and updates documentation for managed identity support in MSAL for Go. The most significant changes are grouped below by theme.

**CI Workflow Improvements:**

* The `.github/workflows/linkchecker.yml` workflow is updated to run on pull requests in addition to pushes, and now ignores the `live` branch for push events.
* A new step is added to the workflow to resolve root-relative links in markdown files (e.g., `/path`) to absolute URLs (`https://learn.microsoft.com/path`) before running the link checker, ensuring that such links are properly validated.

**Link Checker Configuration:**

* The `.lycheeignore` file is updated to ignore all URLs matching `http://localhost.*` and to add `https://aka.ms/region-map` to the ignore list, improving link checker accuracy and reducing false positives.

**Documentation Update:**

* The `msal-go/advanced/managed-identity.md` documentation is updated to state that managed identity support is available starting with MSAL for Go version `1.3.1` (previously `1.3.0-preview`).